### PR TITLE
fix: timeout type value configuration

### DIFF
--- a/charts/powerdns-operator/README.md
+++ b/charts/powerdns-operator/README.md
@@ -31,7 +31,7 @@ The command removes all the Kubernetes components associated with the chart and 
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | annotations | object | `{}` | Annotations to add to the controller deployment. |
-| api.timeoutSeconds | string | `"10"` | Specifies timeout to connect to PowerDNS (in seconds) |
+| api.timeoutSeconds | int | `10` | Specifies timeout to connect to PowerDNS (in seconds) |
 | api.url | string | `"https://powerdns.example.local:8081"` | Specifies the PowerDNS API URL |
 | api.vhost | string | `"localhost"` | Specifies the PowerDNS VHOST |
 | commonLabels | object | `{}` |  |

--- a/charts/powerdns-operator/templates/deployment.yaml
+++ b/charts/powerdns-operator/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
         - --pdns-api-vhost={{ .Values.api.vhost }}
         {{- end }}
         {{- if .Values.api.timeoutSeconds }}
-        - --pdns-api-timeout="{{ .Values.api.timeoutSeconds }}"
+        - --pdns-api-timeout={{ .Values.api.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ .Values.metrics.service.port }}

--- a/charts/powerdns-operator/tests/__snapshot__/controller_test.yaml.snap
+++ b/charts/powerdns-operator/tests/__snapshot__/controller_test.yaml.snap
@@ -35,7 +35,7 @@ should match snapshot of default values:
                 - --metrics-bind-address=:8080
                 - --pdns-api-url=https://powerdns.example.local:8081
                 - --pdns-api-vhost=localhost
-                - --pdns-api-timeout="10"
+                - --pdns-api-timeout=10
               command:
                 - /manager
               envFrom:

--- a/charts/powerdns-operator/values.yaml
+++ b/charts/powerdns-operator/values.yaml
@@ -35,7 +35,7 @@ api:
   vhost: "localhost"
 
   # -- Specifies timeout to connect to PowerDNS (in seconds)
-  timeoutSeconds: "10"
+  timeoutSeconds: 10
 
 rbac:
   create: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ The command removes all the Kubernetes components associated with the chart and 
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | annotations | object | `{}` | Annotations to add to the controller deployment. |
-| api.timeoutSeconds | string | `"10"` | Specifies timeout to connect to PowerDNS (in seconds) |
+| api.timeoutSeconds | int | `10` | Specifies timeout to connect to PowerDNS (in seconds) |
 | api.url | string | `"https://powerdns.example.local:8081"` | Specifies the PowerDNS API URL |
 | api.vhost | string | `"localhost"` | Specifies the PowerDNS VHOST |
 | commonLabels | object | `{}` |  |


### PR DESCRIPTION
```
invalid value "\"10\"" for flag -pdns-api-timeout: parse error
Usage of /manager:
  -enable-http2
        If set, HTTP/2 will be enabled for the metrics and webhook servers
  -health-probe-bind-address string
        The address the probe endpoint binds to. (default ":8081")
  -kubeconfig string
        Paths to a kubeconfig. Only required if out-of-cluster.
  -leader-elect
        Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.
  -metrics-bind-address string
        The address the metric endpoint binds to. (default ":8080")
  -metrics-secure
        If set the metrics endpoint is served securely
  -pdns-api-key string
        The API key to authenticate with the PowerDNS API (default "secret")
  -pdns-api-timeout int
        The timeout for PowerDNS API requests (in seconds) (default 10)
  -pdns-api-url string
        The URL of the PowerDNS API (default "http://powerdns.powerdns.svc.cluster.local:8081")
  -pdns-api-vhost string
        The vhost of the PowerDNS API (default "localhost")
  -zap-devel
        Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLe
  -zap-encoder value
        Zap log encoding (one of 'json' or 'console')
  -zap-log-level value
        Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic'or any integer value > 0 which corresponds to custom debug lev
  -zap-stacktrace-level value
        Zap Level at and above which stacktraces are captured (one of 'info', 'error', 'panic').
  -zap-time-encoding value
        Zap time encoding (one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano'). Defaults to 'epoch'.
```

I believe we should keep it as an integer on operator side and change it to integer as well on the chart side.

With the fix:
```
helm template . --values values.yaml --validate=true |grep -B2 "timeout"
        - --pdns-api-url=https://powerdns.example.local:8081
        - --pdns-api-vhost=localhost
        - --pdns-api-timeout=10
```